### PR TITLE
Decode line into utf-8 before use

### DIFF
--- a/resources/lib/F1TVParser/AccountManager.py
+++ b/resources/lib/F1TVParser/AccountManager.py
@@ -26,6 +26,7 @@ class AccountManager:
         if r.ok:
             in_constants = False
             for line in r.content.splitlines():
+                line = line.decode('utf-8')
                 if 'var ENV_CONST' in line:
                     in_constants = True
                     continue


### PR DESCRIPTION
Just finished installing a RPi 4B with aarch64 gentoo. Got Kodi working using popcornmix's Matrix gbm branch. But clearly it was still missing the killer app... F1TV.

I tested your Matrix_Support branch. After finding your python 3 compatible script.module.cache, I still got some error message and decided to investigate. That tuned out to be quite easy to fix.

With this small fix F1TV is working on Matrix.

After two years of enjoying your excellent app, I'm happy to be of some limited help!